### PR TITLE
Fixed online update checker

### DIFF
--- a/src/main/views/productStatus.ts
+++ b/src/main/views/productStatus.ts
@@ -72,6 +72,7 @@ export class ProductStatusDataProvider extends ExplorerDataProvider {
             return { ...updatePackage, releaseUrl: release.html_url };
           }
         })
+        .filter(Boolean)
         .at(0)
     );
 


### PR DESCRIPTION
The process checking if an update was available had an issue preventing it from working correctly (i.e. it would never find the last SAVF update unless it was in the last release).

This PR fixes this.